### PR TITLE
Patch

### DIFF
--- a/src/schedules/Console.php
+++ b/src/schedules/Console.php
@@ -96,7 +96,7 @@ class Console extends Schedule
         $process->run();
 
         if ($process->isSuccessful()) {
-            $lines = (array)explode("\n", mb_convert_encoding($process->getOutput(), 'UTF-8'));
+            $lines = (array)explode("\n", mb_convert_encoding($process->getOutput(), mb_internal_encoding()));
 
             $data = [];
             foreach ($lines as $index => $line) {

--- a/src/schedules/Console.php
+++ b/src/schedules/Console.php
@@ -96,7 +96,7 @@ class Console extends Schedule
         $process->run();
 
         if ($process->isSuccessful()) {
-            $lines = (array)explode("\n", mb_convert_encoding($process->getOutput(), 'UTF-8', 'UTF-8'));
+            $lines = (array)explode("\n", mb_convert_encoding($process->getOutput(), 'UTF-8'));
 
             $data = [];
             foreach ($lines as $index => $line) {

--- a/src/schedules/Console.php
+++ b/src/schedules/Console.php
@@ -96,7 +96,7 @@ class Console extends Schedule
         $process->run();
 
         if ($process->isSuccessful()) {
-            $lines = (array)explode("\n", $process->getOutput());
+            $lines = (array)explode("\n", mb_convert_encoding($process->getOutput(), 'UTF-8', 'UTF-8'));
 
             $data = [];
             foreach ($lines as $index => $line) {


### PR DESCRIPTION
Hi,

On a server where this module is installed, the process './craft help/list' that builds the list of suggestions was coming out with an unencoded character at the end, which made the json encoding of the suggestions fail, which made the /schedule/new page unusable.

Here's the `$process->getOutput()` dump before I apply my fix 
```
string(1957) "backup backup/db cache cache/flush cache/flush-all cache/flush-schema cache/index clear-caches clear-caches/all clear-caches/asset clear-caches/asset-indexing-data clear-caches/compiled-templates clear-caches/cp-resources clear-caches/data clear-caches/index clear-caches/temp-files clear-caches/transform-indexes cloudflare/purge/purge-all cloudflare/purge/purge-urls fixture fixture/load fixture/unload formidable/send-emails formidable/send-emails/index gc gc/run graphql/dump-schema graphql/print-schema help help/index help/list help/list-action-options help/usage index-assets index-assets/all index-assets/one install install/check install/craft install/plugin invalidate-tags invalidate-tags/all invalidate-tags/graphql invalidate-tags/index invalidate-tags/template mailer/test migrate migrate/all migrate/create migrate/down migrate/fresh migrate/history migrate/mark migrate/new migrate/redo migrate/to migrate/up off off/index on on/index plugin/disable plugin/enable plugin/install plugin/uninstall project-config/apply project-config/diff project-config/rebuild project-config/sync project-config/touch project-config/write queue queue/exec queue/info queue/listen queue/release queue/retry queue/run resave/assets resave/categories resave/entries resave/matrix-blocks resave/tags resave/users restore restore/db schedules/list schedules/run seo/upgrade/to-new-data-format serve serve/index setup setup/app-id setup/db setup/db-cache-table setup/db-creds setup/index setup/php-session-table setup/security-key setup/welcome shell shell/index tests/setup tests/test update update/composer-install update/info update/update utils/ascii-filenames utils/ascii-filenames/index utils/fix-element-uids utils/fix-element-uids/index utils/prune-revisions utils/prune-revisions/index utils/repair/category-group-structure utils/repair/project-config utils/repair/section-structure utils/update-usernames utils/update-usernames/index �" 
```
I have no idea where this weird character is coming from, I'm happy to dig further if you have ideas, the server is a centos 7 with cpanel, php7.3, here's the exact command :

/usr/local/bin/ea-php73 /home/inspir/public_html/dev1/windowsupply/craft

The fix decodes the character but it leaves an interrogation mark at the end of the string, but it's removed by the further treatment and it does not appear in the suggestions.