### PR TITLE
[Feat] A command to run the scheduler every minute, without relying on cron.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,56 +1,57 @@
 {
-    "name": "panlatent/schedule",
-    "description": "Schedule plugin for CraftCMS 3",
-    "type": "craft-plugin",
-    "version": "0.2.2.1",
-    "keywords": [
-        "craft",
-        "cms",
-        "craftcms",
-        "craft-plugin",
-        "schedule",
-        "crontab",
-        "job"
-    ],
-    "homepage": "https://github.com/panlatent/schedule",
-    "support": {
-        "docs": "https://schedule.panlatent.com",
-        "issues": "https://github.com/panlatent/schedule/issues"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "panlatent@gmail.com",
-            "homepage": "https://panlatent.com/"
-        }
-    ],
-    "require": {
-        "craftcms/cms": "^3.1.0",
-        "omnilight/yii2-scheduling": "^1.1",
-        "symfony/process": "^4.2||^5.0",
-        "guzzlehttp/guzzle": "^6.3",
-        "panlatent/cron-expression-descriptor": "^1.0.2"
-    },
-    "suggest": {
-        "ext-intl": "Help translate cron express description"
-    },
-    "autoload": {
-        "psr-4": {
-          "panlatent\\schedule\\": "src/"
-        }
-    },
-    "extra": {
-        "name": "Schedule",
-        "handle": "schedule",
-        "hasCpSettings": true,
-        "hasCpSection": true,
-        "changelogUrl": "https://raw.githubusercontent.com/panlatent/schedule/master/CHANGELOG.md",
-        "class": "panlatent\\schedule\\Plugin",
-        "branch-alias": {
-            "dev-master": "0.2.x-dev"
-        }
-    },
-    "require-dev": {
-        "codeception/codeception": "^2.5"
+  "name": "panlatent/schedule",
+  "description": "Schedule plugin for CraftCMS 3",
+  "type": "craft-plugin",
+  "version": "0.2.2.1",
+  "keywords": [
+    "craft",
+    "cms",
+    "craftcms",
+    "craft-plugin",
+    "schedule",
+    "crontab",
+    "job"
+  ],
+  "homepage": "https://github.com/panlatent/schedule",
+  "support": {
+    "docs": "https://schedule.panlatent.com",
+    "issues": "https://github.com/panlatent/schedule/issues"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "panlatent@gmail.com",
+      "homepage": "https://panlatent.com/"
     }
+  ],
+  "require": {
+    "craftcms/cms": "^3.1.0",
+    "nesbot/carbon": "^1.22 || ^2.10",
+    "omnilight/yii2-scheduling": "^1.1",
+    "symfony/process": "^4.2||^5.0",
+    "guzzlehttp/guzzle": "^6.3",
+    "panlatent/cron-expression-descriptor": "^1.0.2"
+  },
+  "suggest": {
+    "ext-intl": "Help translate cron express description"
+  },
+  "autoload": {
+    "psr-4": {
+      "panlatent\\schedule\\": "src/"
+    }
+  },
+  "extra": {
+    "name": "Schedule",
+    "handle": "schedule",
+    "hasCpSettings": true,
+    "hasCpSection": true,
+    "changelogUrl": "https://raw.githubusercontent.com/panlatent/schedule/master/CHANGELOG.md",
+    "class": "panlatent\\schedule\\Plugin",
+    "branch-alias": {
+      "dev-master": "0.2.x-dev"
+    }
+  },
+  "require-dev": {
+    "codeception/codeception": "^2.5"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "craftcms/cms": "^3.1.0",
         "omnilight/yii2-scheduling": "^1.1",
-        "symfony/process": "^4.2",
+        "symfony/process": "^4.2||^5.0",
         "guzzlehttp/guzzle": "^6.3",
         "panlatent/cron-expression-descriptor": "^1.0.2"
     },


### PR DESCRIPTION
This scheduler relies on cron to be executed every minute. It's rock solid and in most cases you should stick to using it.

If you want to simulate the scheduler running every minute in a test environment / Kuberneties cluster, using cron can be cumbersome. This PR adds a command to run the scheduler every minute, without relying on cron.

`./craft schedules/cron`
This command will never end. Behind the scenes it will execute `./craft schedules/run` every minute.