### PR TITLE
PHP 8 fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "omnilight/yii2-scheduling": "^1.1",
         "symfony/process": "^4.2",
         "guzzlehttp/guzzle": "^6.3",
-        "panlatent/cron-expression-descriptor": "^1.0.2"
+        "panlatent/cron-expression-descriptor": "^1.0"
     },
     "suggest": {
         "ext-intl": "Help translate cron express description"


### PR DESCRIPTION
This plugin doesn't work on PHP 8 (issue in panlatent/cron-expression-descriptor).

The issue has already been solved on the dependency (panlatent/cron-expression-descriptor) 1.0.4 from what I can see, but this plugin doesn't allow that update, this PR fixes that