### PR TITLE
add log clear command with time offset option

### DIFF
--- a/src/console/SchedulesController.php
+++ b/src/console/SchedulesController.php
@@ -181,7 +181,11 @@ class SchedulesController extends Controller
             }
 
             $this->stderr($error .  ".\n", Console::FG_RED);
+
+            return;
         }
+
+        $this->stdout("Provide the expire or all option to use this command. \n", Console::FG_YELLOW);
     }
 
     protected function triggerCronCall(array $events = null)

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -9,6 +9,7 @@ namespace panlatent\schedule\models;
 
 use Craft;
 use craft\base\Model;
+use panlatent\schedule\validators\CarbonStringIntervalValidator;
 use panlatent\schedule\validators\PhpBinaryValidator;
 
 /**
@@ -38,6 +39,11 @@ class Settings extends Model
     public $customCpNavName;
 
     /**
+     * @var string|null
+     */
+    public $logExpireAfter;
+
+    /**
      * @deprecated
      * @var bool
      */
@@ -52,9 +58,10 @@ class Settings extends Model
     public function rules(): array
     {
         return [
-            [['cliPath', 'customName', 'customCpNavName'], 'string'],
+            [['cliPath', 'customName', 'customCpNavName', 'logExpireAfter'], 'string'],
             [['modifyPluginName'], 'boolean'],
             [['cliPath'], PhpBinaryValidator::class, 'minVersion' => '7.1', 'allowParseEnv' => true],
+            [['logExpireAfter'], CarbonStringIntervalValidator::class],
         ];
     }
 

--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -7,6 +7,7 @@
 
 namespace panlatent\schedule\services;
 
+use Carbon\Carbon;
 use Craft;
 use craft\db\Query;
 use craft\helpers\Db;
@@ -111,6 +112,22 @@ class Logs extends Component
             ->createCommand()
             ->delete(Table::SCHEDULELOGS, [
                 'scheduleId' => $scheduleId,
+            ])
+            ->execute();
+
+        return true;
+    }
+
+    /**
+     * @param Carbon $datetime
+     * @return bool
+     */
+    public function deleteLogsByDateCreated($datetime): bool
+    {
+        Craft::$app->getDb()
+            ->createCommand()
+            ->delete(Table::SCHEDULELOGS, [
+                '<=', 'dateCreated', $datetime,
             ])
             ->execute();
 

--- a/src/templates/_layouts/settings.twig
+++ b/src/templates/_layouts/settings.twig
@@ -8,6 +8,7 @@
 {% if currentUser.admin %}
     {% set navItems = {
         'general': { title: "General"|t('schedule') },
+        'logs': { title: "Logs"|t('schedule') },
     } %}
 {% endif %}
 

--- a/src/templates/settings/logs/index.twig
+++ b/src/templates/settings/logs/index.twig
@@ -1,0 +1,26 @@
+{% extends "schedule/_layouts/settings" %}
+
+{% set fullPageFomr = true %}
+{% set settings = craft.schedule.settings %}
+
+{% import "_includes/forms" as forms %}
+
+{% block content %}
+    <h2>{{ "Log Settings"|t('schedule') }}</h2>
+
+    <form method="post" accept-charset="UTF-8">
+        <input type="hidden" name="action" value="schedule/settings/save-general">
+        {{ csrfInput() }}
+
+        {{ forms.textField({
+            label: "Expiry threshold"|t('schedule'),
+            instructions: 'Default expiry time used when calling the `schedules/clear-logs` command.'|t('schedule'),
+            id: "logExpireAfter",
+            name: "logExpireAfter",
+            value: settings.logExpireAfter,
+            errors: settings.getErrors('logExpireAfter'),
+        }) }}
+
+        <button class="btn submit">{{ "Save"|t('app') }}</button>
+    </form>
+{% endblock %}

--- a/src/translations/zh/schedule.php
+++ b/src/translations/zh/schedule.php
@@ -111,4 +111,6 @@ return [
     'Add Header Value' => '添加首部值',
     'Add URL Parameter' => '添加 URL 参数',
     'Add Value' => '添加值',
+    'Expiry threshold' => '????',
+    'Default expiry time used when calling the `schedules/clear-logs` command.' => '???? `schedules/clear-logs`',
 ];

--- a/src/validators/CarbonStringIntervalValidator.php
+++ b/src/validators/CarbonStringIntervalValidator.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Schedule plugin for CraftCMS
+ *
+ * https://github.com/panlatent/schedule
+ */
+
+namespace panlatent\schedule\validators;
+
+use Carbon\CarbonInterval;
+use Carbon\Exceptions\InvalidIntervalException;
+use yii\validators\Validator;
+
+
+/**
+ * Class CarbonStringIntervalValidator
+ *
+ * @package panlatent\schedule\validators
+ * @author Panlatent <panlatent@gmail.com>
+ */
+class CarbonStringIntervalValidator extends Validator
+{
+    // Properties
+    // =========================================================================
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function validateValue($value)
+    {
+        try {
+            if(CarbonInterval::make($value) === null) {
+                return ['Not a valid Carbon interval "{value}"', ['value' => $value]];
+            }
+
+            return null;
+        } catch(InvalidIntervalException $e) {
+            return ['Not a valid Carbon interval "{value}"', ['value' => $value]];
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `schedules/clear-logs` command, optionally a time offset can be supplied using the `offset` param. This way it is possible to keep recent logs and discart of old ones eg; `schedules/clear-logs --offset=12h`.

This command could be triggered using the scheduler itself in order to keep the logs table from exponentially growing.