### PR TITLE
Allow multiple argument for CLI commands

### DIFF
--- a/src/schedules/Console.php
+++ b/src/schedules/Console.php
@@ -80,8 +80,10 @@ class Console extends Schedule
             PHP_BINARY,
             self::CRAFT_CLI_SCRIPT,
             $this->command,
-            $this->arguments,
         ];
+
+        $arguments = explode(' ', $this->arguments);
+        $command = array_merge($command, $arguments);
 
         if ($this->user) {
             $command = array_merge(['sudo -u', $this->user], $command);


### PR DESCRIPTION
Allow multiple argument divided with space in command arguments.

Before this PR:
if you use few arguments to Console Command (ex.: a b c) you will get an error
 Error: Missing required arguments: b, c
 
![image](https://github.com/user-attachments/assets/2dd652ad-24aa-4524-a9da-a5686c9701ea)



After this PR:
Command with few arguments successfully completed
![image](https://github.com/user-attachments/assets/88a088d4-9f45-47d9-840e-2042bbf0761c)

